### PR TITLE
Check for null in _createEventHandler handler

### DIFF
--- a/src/standard/events.html
+++ b/src/standard/events.html
@@ -132,7 +132,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     _createEventHandler: function(node, eventName, methodName) {
       var host = this;
       var handler = function(e) {
-        if (host[methodName]) {
+        if (!e) {
+          host._warn(host._logf('_createEventHandler', 'listener method `' +
+            methodName + '` called with null event'));
+        } else if (host[methodName]) {
           host[methodName](e, e.detail);
         } else {
           host._warn(host._logf('_createEventHandler', 'listener method `' +


### PR DESCRIPTION
<!-- Instructions: https://github.com/Polymer/polymer/blob/master/CONTRIBUTING.md#contributing-pull-requests -->
### Reference Issue
<!-- Example: Fixes #1234 -->

YouTube Polymer experiments are seeing many reports of errors in _createEventHandler: http://imgur.com/a/rZUnj

Propose adding null check.

Everything we know of this JS runtime exception:
Chrome: Cannot read property 'detail' of undefined
Edge: Unable to get property 'detail' of undefined or null reference
Safari(?): undefined is not an object (evaluating 'e.detail')

According to our tools, these pages exhibit the error but we are unable to reproduce:
21 https://www.youtube.com/watch?v=6Mgqbai3fKo
13 https://www.youtube.com/watch?v=OXq-JP8w5H4
12 https://www.youtube.com/watch?v=iOe6dI2JhgU
9 https://www.youtube.com/watch?v=6C_s56iscpQ
9 https://www.youtube.com/watch?v=PT2_F-1esPk
8 https://www.youtube.com/watch?v=_GuOjXYl5ew
7 https://www.youtube.com/watch?v=AMTAQ-AJS4Y
7 https://www.youtube.com/watch?v=JWESLtAKKlU
7 https://www.youtube.com/watch?v=L_jWHffIx5E
7 https://www.youtube.com/watch?v=aKuivabiOns
(...)